### PR TITLE
update go installation instructions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -28,7 +28,7 @@ sequenceDiagram
 ```
 
 ### Installation
-```go get -u github.com/glebarez/pgssl```
+```go install github.com/glebarez/pgssl```
 
 ### Usage example
 ```pgssl -p postgres-server:5432 -l :15432 -k client.key -c client.crt```


### PR DESCRIPTION
go get is deprecated: https://go.dev/doc/go-get-install-deprecation