### PR TITLE
Remove client cert necessity

### DIFF
--- a/main.go
+++ b/main.go
@@ -38,11 +38,8 @@ func main() {
 	if options.pgAddress == "" {
 		argFatal("postgres address must be specified")
 	}
-	if options.clientCertPath == "" {
-		argFatal("clientCertPath must be specified")
-	}
-	if options.clientKeyPath == "" {
-		argFatal("clientKeyPath must be specified")
+	if (options.clientCertPath == "") != (options.clientKeyPath == "") {
+		argFatal("You must specify both clientKeyPath and clientCertPath to use a client certificate")
 	}
 
 	// load client certificate and key

--- a/main.go
+++ b/main.go
@@ -40,23 +40,33 @@ func main() {
 	if options.pgAddress == "" {
 		argFatal("postgres address must be specified")
 	}
-	if options.clientCertPath == "" {
-		argFatal("clientCertPath must be specified")
-	}
-	if options.clientKeyPath == "" {
-		argFatal("clientKeyPath must be specified")
-	}
-
-	// load client certificate and key
-	cert, err := tls.LoadX509KeyPair(options.clientCertPath, options.clientKeyPath)
-	if err != nil {
-		log.Fatal(err)
-	}
 
 	// create pgSSL instance
 	pgSSL := &PgSSL{
-		pgAddr:     options.pgAddress,
-		clientCert: &cert,
+		pgAddr: options.pgAddress,
+	}
+
+	if options.useClientKeyPair {
+		if options.clientCertPath == "" {
+			argFatal("clientCertPath must be specified")
+		}
+		if options.clientKeyPath == "" {
+			argFatal("clientKeyPath must be specified")
+		}
+
+		// load client certificate and key
+		cert, err := tls.LoadX509KeyPair(options.clientCertPath, options.clientKeyPath)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		// recreate pgSSL instance with client keypair
+		pgSSL = &PgSSL{
+			pgAddr:     options.pgAddress,
+			clientCert: &cert,
+		}
+	} else {
+		log.Println("Not using client keypair")
 	}
 
 	// bind listening socket

--- a/main.go
+++ b/main.go
@@ -10,10 +10,11 @@ import (
 )
 
 var options struct {
-	listenAddress  string
-	pgAddress      string
-	clientCertPath string
-	clientKeyPath  string
+	listenAddress    string
+	pgAddress        string
+	clientCertPath   string
+	clientKeyPath    string
+	useClientKeyPair bool
 }
 
 func argFatal(s string) {
@@ -33,6 +34,7 @@ func main() {
 	flag.StringVar(&options.pgAddress, "p", "", "Postgres address")
 	flag.StringVar(&options.clientCertPath, "c", "", "clientCertPath")
 	flag.StringVar(&options.clientKeyPath, "k", "", "clientKeyPath")
+	flag.BoolVar(&options.useClientKeyPair, "use-client-keypair", true, "Whether to use a client keypair")
 	flag.Parse()
 
 	if options.pgAddress == "" {

--- a/main.go
+++ b/main.go
@@ -42,16 +42,23 @@ func main() {
 		argFatal("You must specify both clientKeyPath and clientCertPath to use a client certificate")
 	}
 
-	// load client certificate and key
-	cert, err := tls.LoadX509KeyPair(options.clientCertPath, options.clientKeyPath)
-	if err != nil {
-		log.Fatal(err)
-	}
-
 	// create pgSSL instance
 	pgSSL := &PgSSL{
-		pgAddr:     options.pgAddress,
-		clientCert: &cert,
+		pgAddr: options.pgAddress,
+	}
+
+	if (options.clientCertPath != "") && (options.clientKeyPath != "") {
+		// load client certificate and key
+		cert, err := tls.LoadX509KeyPair(options.clientCertPath, options.clientKeyPath)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		// recreate pgSSL instance with our client cert
+		pgSSL = &PgSSL{
+			pgAddr:     options.pgAddress,
+			clientCert: &cert,
+		}
 	}
 
 	// bind listening socket

--- a/pgssl.go
+++ b/pgssl.go
@@ -76,9 +76,16 @@ func (p *PgSSL) HandleConn(clientConn net.Conn) error {
 
 	// upgrade connection to TLS
 	pgTLSconn := tls.Client(pgConn, &tls.Config{
-		GetClientCertificate: func(cri *tls.CertificateRequestInfo) (*tls.Certificate, error) { return p.clientCert, nil },
-		InsecureSkipVerify:   true,
+		InsecureSkipVerify: true,
 	})
+
+	if p.clientCert != nil {
+		// Add client keypair to our upgraded connection
+		pgTLSconn = tls.Client(pgConn, &tls.Config{
+			GetClientCertificate: func(cri *tls.CertificateRequestInfo) (*tls.Certificate, error) { return p.clientCert, nil },
+			InsecureSkipVerify:   true,
+		})
+	}
 
 	// upgrade frontend
 	frontend = pgproto3.NewFrontend(pgproto3.NewChunkReader(pgTLSconn), pgTLSconn)

--- a/readme.md
+++ b/readme.md
@@ -32,4 +32,4 @@ sequenceDiagram
 
 ### Usage examples
 - ```pgssl -p postgres-server:5432 -l :15432 -k client.key -c client.crt```
-- ```pgssl -p postgres-server:5432 -l :15432 -use-client-keypair=false```
+- ```pgssl -p postgres-server:5432 -l :15432```

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,5 @@
 # pgSSL
-```pgSSL``` is a proxy for ```PostgreSQL``` that wraps plain TCP connections (```sslmode=disable```) into SSL and provides client certificate to the backend ```PostgreSQL``` server. This way it allows SSL encryption and certificate-based authentication for plain-text ```PostgreSQL``` clients.
+```pgSSL``` is a proxy for ```PostgreSQL``` that wraps plain TCP connections (```sslmode=disable```) into SSL and provides (optional) client certificate to the backend ```PostgreSQL``` server. This way it allows SSL encryption and certificate-based authentication for plain-text ```PostgreSQL``` clients.
 
 ### Motivation
 PostgreSQL listens to both plain and SSL connections on a single port, therefore it has its own handshake that precedes the usual SSL/TLS handshake.
@@ -30,5 +30,6 @@ sequenceDiagram
 ### Installation
 ```go get -u github.com/glebarez/pgssl```
 
-### Usage example
-```pgssl -p postgres-server:5432 -l :15432 -k client.key -c client.crt```
+### Usage examples
+- ```pgssl -p postgres-server:5432 -l :15432 -k client.key -c client.crt```
+- ```pgssl -p postgres-server:5432 -l :15432 -use-client-keypair=false```


### PR DESCRIPTION
Not everyone needs to provide a client certificate to their upstream postgresql, so I've added a flag which allows you to turn off the requirement at run time 😄 