### PR TITLE
feat: add optional connection password

### DIFF
--- a/main.go
+++ b/main.go
@@ -10,10 +10,11 @@ import (
 )
 
 var options struct {
-	listenAddress  string
-	pgAddress      string
-	clientCertPath string
-	clientKeyPath  string
+	listenAddress      string
+	pgAddress          string
+	clientCertPath     string
+	clientKeyPath      string
+	connectionPassword string
 }
 
 func argFatal(s string) {
@@ -33,6 +34,7 @@ func main() {
 	flag.StringVar(&options.pgAddress, "p", "", "Postgres address")
 	flag.StringVar(&options.clientCertPath, "c", "", "clientCertPath")
 	flag.StringVar(&options.clientKeyPath, "k", "", "clientKeyPath")
+	flag.StringVar(&options.connectionPassword, "s", "", "Password used to authenticate to pgssl")
 	flag.Parse()
 
 	if options.pgAddress == "" {
@@ -44,7 +46,8 @@ func main() {
 
 	// create pgSSL instance
 	pgSSL := &PgSSL{
-		pgAddr: options.pgAddress,
+		pgAddr:             options.pgAddress,
+		connectionPassword: options.connectionPassword,
 	}
 
 	if (options.clientCertPath != "") && (options.clientKeyPath != "") {
@@ -56,8 +59,9 @@ func main() {
 
 		// recreate pgSSL instance with our client cert
 		pgSSL = &PgSSL{
-			pgAddr:     options.pgAddress,
-			clientCert: &cert,
+			pgAddr:             options.pgAddress,
+			clientCert:         &cert,
+			connectionPassword: options.connectionPassword,
 		}
 	}
 


### PR DESCRIPTION
Hi @glebarez 
I am considering running pgssl in a shared k8s cluster.
To provide a barrier against everyone being able to connect to pgssl from inside the cluster, I have implemented an optional "connection password" flag.
I use Postgres' client password in order to authenticate the client to the pgssl backend. If the password is not supplied whilst starting pgssl, no new logic is run.
Therefore, a new `-s` flag is introduced to supply a password when starting pgssl