### PR TITLE
feat: pgssl password with env var

### DIFF
--- a/main.go
+++ b/main.go
@@ -34,7 +34,8 @@ func main() {
 	flag.StringVar(&options.pgAddress, "p", "", "Postgres address")
 	flag.StringVar(&options.clientCertPath, "c", "", "clientCertPath")
 	flag.StringVar(&options.clientKeyPath, "k", "", "clientKeyPath")
-	flag.StringVar(&options.connectionPassword, "s", "", "Password used to authenticate to pgssl")
+	flag.StringVar(&options.connectionPassword, "s", "", "Password used to authenticate to pgssl\n" +
+		"can alternatively be specified via the PGSSL_PASSWORD environment variable")
 	flag.Parse()
 
 	if options.pgAddress == "" {
@@ -42,6 +43,15 @@ func main() {
 	}
 	if (options.clientCertPath == "") != (options.clientKeyPath == "") {
 		argFatal("You must specify both clientKeyPath and clientCertPath to use a client certificate")
+	}
+
+	var envPassword string = os.Getenv("PGSSL_PASSWORD")
+	if envPassword != "" {
+		if options.connectionPassword != "" {
+			log.Println("PGSSL_PASSWORD and -s <password> specified. Ignoring env variable.")
+		} else {
+			options.connectionPassword = envPassword
+		}
 	}
 
 	// create pgSSL instance

--- a/readme.md
+++ b/readme.md
@@ -33,3 +33,4 @@ sequenceDiagram
 ### Usage examples
 - ```pgssl -p postgres-server:5432 -l :15432 -k client.key -c client.crt```
 - ```pgssl -p postgres-server:5432 -l :15432```
+- ```PGSSL_PASSWORD=changeme pgssl -p postgres-server:5432 -l :15432```


### PR DESCRIPTION
Extend the password function added in #5 by allowing the password to be specified via an environment variable.
This may prevent secret disclosure because the password does not have to be provided via CLI anymore.
Variable Name is `PGSSL_PASSWORD`